### PR TITLE
Fix #750

### DIFF
--- a/generators/ionic/templates/src/app/pages/entities/_entity-update.html.ejs
+++ b/generators/ionic/templates/src/app/pages/entities/_entity-update.html.ejs
@@ -99,7 +99,7 @@ _%>
                         {{ 'ITEM_CREATE_CHOOSE_IMAGE' | translate }}
                     </ion-button>
                     <%_ } else { _%>
-                    <input type="file" data-cy="<%= fieldName %>" #fileInput (change)="setFileData($event, '<%= fieldName %>', false)"/>
+                    <input type="file" data-cy="<%= fieldName %>" (change)="setFileData($event, '<%= fieldName %>', false)"/>
                     <%_ } _%>
                 </div>
                 <%_ } else if (['LocalDate', 'Instant', 'ZonedDateTime'].includes(fieldType)) { _%>

--- a/generators/ionic/templates/src/app/pages/entities/_entity-update.ts.ejs
+++ b/generators/ionic/templates/src/app/pages/entities/_entity-update.ts.ejs
@@ -289,8 +289,9 @@ _%>
       Object.assign(this.<%= entityInstance %>, patchValue);
       this.form.patchValue(patchValue);
     }
-<%_ } else if (fieldsContainBlob) { _%>
+<%_ } 
 
+    if (fieldsContainBlob) { _%>
     setFileData(event, field, isImage) {
         this.dataUtils.loadFileToForm(event, this.form, field, isImage).subscribe();
     }


### PR DESCRIPTION
Hi @mraible 
I have tested the fix with the **bug-tracker.jh** modified (I added in Attachment entity two Blob and two ImageBlob fields):

```
entity Project {
  name String
}

entity Label {
  label String required minlength(3)
}

application {
  config {
    prodDatabaseType postgresql,
  }
  entities *
}

entity Ticket {
  title String required
  description String
  dueDate LocalDate
  date ZonedDateTime
  status Status
  type Type
  priority Priority
}

entity Attachment {
  name String required minlength(3)
  file1 Blob,
  file2 Blob,
  imageFile1 ImageBlob,
  imageFile2 ImageBlob
}

relationship ManyToMany {
  Ticket{label(label)} to Label{ticket}
}

relationship ManyToOne {
  Ticket{project(name)} to Project
  Ticket{assignedTo(login)} to User
  Ticket{reportedBy(login)} to User
  Comment{login} to User
}

relationship OneToMany {
  Comment{parent} to Comment{child}
  Ticket to Attachment 
}

enum Status {
  OPEN("Open")
  WAITING_FOR_RESPONSE("Waiting for Customer Response")
  CLOSED("Closed")
  DUPLICATE("Duplicate")
  IN_PROGRESS("In Progress")
  REOPENED("Reopened")
  CANNOT_REPRODUCE("Cannot Reproduce")
  SOLVED("Solved")
  WONT_IMPLEMENT("Won't Implement")
  VERIFIED("Verified")
  
}

enum Type {
  BUG("Bug"),
  FEATURE("Feature")
}

enum Priority {
  HIGHEST("Highest")
  HIGHER("Higher")
  HIGH("High")
  NORMAL("Normal")
  LOW("Low")
  LOWER("Lower")
  LOWERST("Lowest")
}

entity Comment {
  date ZonedDateTime
  text String
}

paginate Ticket with pagination
``` 

I have the following considerations for the bug commented in this #750 issue:

1.  For Blob field @ViewChild fileInput annotation is not declared in the **<entity>-update.ts** file. So I have deleted #fileInput attribute in input html related tag. Besides the input text uses a **setFileData** method.
2. The **getPicture()** method is used for ImageBlob field, that calls camera api without **this.fileInput.nativeElement.click()** method (fileInput was for Blob field and it isn't in related ts file). 
3. I have modified **<entity>-update.ts** template for a invalid selection in case that there are Blob and ImageBlob fields in the same entity. There was a if-else statement that not includes this situation.
Pleas give me a feedback as you can.
Thanks for the attention and your time.

