### PR TITLE
Remove experimentalSessionAndOrigin from Cypress configuration

### DIFF
--- a/generators/ionic/resources/base/cypress.config.ts
+++ b/generators/ionic/resources/base/cypress.config.ts
@@ -16,8 +16,7 @@ export const defaultConfig = {
       return (await import('./cypress/plugins/index')).default(on, config);
     },
     baseUrl: 'http://localhost:8100/',
-    supportFile: 'cypress/support/index.ts',
-    experimentalSessionAndOrigin: true,
+    supportFile: 'cypress/support/index.ts'
   },
 };
 


### PR DESCRIPTION
It's [no longer needed](https://github.com/jhipster/generator-jhipster-ionic/actions/runs/5857584134/job/15879746319#step:15:209).