### PR TITLE
disable dependabot for root package.json.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,6 @@ updates:
       interval: 'weekly'
 
   - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      # generator-jhipster dependency is not fixed, it needs at least it's own yeoman-environment version.
-      # Don't update yeoman-environment and let generator-jhipster dependency version be dedupped.
-      - dependency-name: 'yeoman-environment'
-
-  - package-ecosystem: 'npm'
     directory: '/generators/ionic/resources/base'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
We should follow `jhipster generate-blueprint` dependencies.