### PR TITLE
group dependabot dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     directory: '/generators/ionic/resources/base'
     schedule:
       interval: 'weekly'
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,6 @@ updates:
       interval: 'weekly'
 
   - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      # generator-jhipster dependency is not fixed, it needs at least it's own yeoman-environment version.
-      # Don't update yeoman-environment and let generator-jhipster dependency version be dedupped.
-      - dependency-name: 'yeoman-environment'
-
-  - package-ecosystem: 'npm'
     directory: '/generators/ionic/resources/base'
     schedule:
       interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,9 @@ updates:
       angular:
         patterns:
           - "@angular/*"
+      angular-eslint:
+        patterns:
+          - "@angular-eslint/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"

--- a/generators/ionic/resources/base/package.json
+++ b/generators/ionic/resources/base/package.json
@@ -39,7 +39,7 @@
     "@fortawesome/angular-fontawesome": "0.11.1",
     "@fortawesome/fontawesome-svg-core": "6.4.2",
     "@fortawesome/free-solid-svg-icons": "6.4.2",
-    "@ionic/angular": "^7.0.10",
+    "@ionic/angular": "7.4.4",
     "@ionic/pwa-elements": "^3.1.1",
     "@ionic/storage": "^4.0.0",
     "@ionic/storage-angular": "^4.0.0",


### PR DESCRIPTION
We should follow `jhipster generate-blueprint` dependencies.