### PR TITLE
Update dependencies with npm-check-updates

### DIFF
--- a/generators/ionic/resources/base/package.json
+++ b/generators/ionic/resources/base/package.json
@@ -40,7 +40,7 @@
     "@fortawesome/fontawesome-svg-core": "6.5.2",
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@ionic/angular": "8.2.0",
-    "@ionic/pwa-elements": "^3.1.1",
+    "@ionic/pwa-elements": "^3.3.0",
     "@ionic/storage": "^4.0.0",
     "@ionic/storage-angular": "^4.0.0",
     "@ngx-translate/core": "15.0.0",
@@ -48,8 +48,8 @@
     "capacitor-secure-storage-plugin": "0.10.0",
     "ionic-appauth": "2.1.0",
     "rxjs": "~7.8.1",
-    "tslib": "^2.4.0",
-    "zone.js": "~0.14.2"
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.6"
   },
   "devDependencies": {
     "@angular-builders/jest": "~18.0.0-beta.3",
@@ -63,23 +63,22 @@
     "@angular/compiler-cli": "~18.0.1",
     "@angular/language-service": "~18.0.1",
     "@capacitor/cli": "6.0.0",
-    "@cypress/schematic": "^2.0.3",
     "@ionic/angular-toolkit": "^11.0.1",
-    "@ionic/cli": "^7.1.1",
+    "@ionic/cli": "^7.2.0",
     "@types/jest": "29.5.12",
-    "@types/node": "^20.2.3",
-    "@typescript-eslint/eslint-plugin": "7.11.0",
-    "@typescript-eslint/parser": "7.11.0",
+    "@types/node": "^20.14.1",
+    "@typescript-eslint/eslint-plugin": "7.12.0",
+    "@typescript-eslint/parser": "7.12.0",
     "cypress": "13.10.0",
-    "eslint": "^8.22.0",
+    "eslint": "^9.4.0",
     "eslint-plugin-import": "2.29.1",
-    "eslint-plugin-jsdoc": "48.2.6",
+    "eslint-plugin-jsdoc": "48.2.7",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "ionic-mocks-jest": "1.3.3",
     "jest": "29.7.0",
     "jest-localstorage-mock": "2.4.26",
     "jest-preset-angular": "14.1.0",
-    "prettier": "3.2.5",
-    "typescript": "~5.4.2"
+    "prettier": "3.3.0",
+    "typescript": "~5.4.5"
   }
 }


### PR DESCRIPTION
```
 @ionic/cli                         ^7.1.1  →    ^7.2.0
 @ionic/pwa-elements                ^3.1.1  →    ^3.3.0
 @types/node                       ^20.2.3  →  ^20.14.1
 @typescript-eslint/eslint-plugin   7.11.0  →    7.12.0
 @typescript-eslint/parser          7.11.0  →    7.12.0
 eslint                            ^8.22.0  →    ^9.4.0
 eslint-plugin-jsdoc                48.2.6  →    48.2.7
 prettier                            3.2.5  →     3.3.0
 tslib                              ^2.4.0  →    ^2.6.2
 typescript                         ~5.4.2  →    ~5.4.5
 zone.js                           ~0.14.2  →   ~0.14.6
```

Also removed Cypress Schematic since it's probably not used. 